### PR TITLE
Add docs workflow for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build documentation
+        run: make docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          publish_branch: gh-pages
+          force_orphan: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+docs:
+	$(MAKE) -C docs html
+
+.PHONY: docs


### PR DESCRIPTION
## Summary
- create a simple `Makefile` with a `docs` target
- add a GitHub Actions workflow that builds the docs on push and publishes to Pages

## Testing
- `pytest -q`
- `make docs`

------
https://chatgpt.com/codex/tasks/task_e_68418f00e5988322a1d76cd07837c64c