### PR TITLE
Fix docs workflow with separate requirements

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-pages.txt
       - name: Build docs
         run: |
           sphinx-build -b html docs docs/_build/html

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 
 This repository contains algorithm implementations, datasets used for testing and
 unit tests. Use `create_algorithm.py` to scaffold new algorithms.
+
+## Requirements
+
+Two requirements files are provided:
+
+* `requirements.txt` - full dependencies for running the project locally.
+* `requirements-pages.txt` - smaller set used when building the documentation.

--- a/requirements-pages.txt
+++ b/requirements-pages.txt
@@ -1,0 +1,10 @@
+cudf
+kvikio
+numpy
+pandas
+psutil
+numba
+line_profiler
+snakeviz
+matplotlib
+sphinx


### PR DESCRIPTION
## Summary
- exclude CuPy from docs build requirements
- add a new requirements-pages.txt file for GitHub Pages
- update the workflow to use the lightweight requirements file
- document the two requirements files in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429ba94f9483229a1b4ce836fbd89d