### PR TITLE
Fix GH Pages deploy permission

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push to `gh-pages` by granting write `contents` permissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ac59a70483228c793ae56fc2ca3c